### PR TITLE
Add code to solve problem 058

### DIFF
--- a/058/058.rb
+++ b/058/058.rb
@@ -1,0 +1,35 @@
+class Problem058
+  def prime?(n)
+    return false if n <= 1 || (n != 2 && n % 2 == 0)
+    return true if n == 2
+   
+    limit = Math.sqrt(n).ceil
+    3.step(limit, 2) do |i|
+      return false if n % i == 0
+    end
+    return true
+  end
+  
+  def compute()
+    n = 3
+    arr_len = 1
+    prime_len = 0
+    arr = []
+    loop do
+        [*1..4].each do |i|
+          j = (n-2)**2+i*(n-1)
+          if prime?(j)
+              arr.push(j)
+              prime_len += 1
+          end
+        end
+        arr_len += 4
+        ratio = (prime_len/arr_len.to_f)
+        p "n = #{n}, ratio = #{ratio}"
+        break if ratio < 0.1
+        n += 2
+    end
+    return n
+  end
+end
+p Problem058.new().compute()

--- a/058/Cargo.toml
+++ b/058/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+
+name = "problem_058"
+version = "0.0.1"
+
+[dependencies]

--- a/058/problem.md
+++ b/058/problem.md
@@ -1,0 +1,18 @@
+---
+title: Spiral primes
+---
+# Problem 58
+
+Starting with 1 and spiralling anticlockwise in the following way, a square spiral with side length 7 is formed.
+
+37 36 35 34 33 32 31
+38 17 16 15 14 13 30
+39 18  5  4  3 12 29
+40 19  6  1  2 11 28
+41 20  7  8  9 10 27
+42 21 22 23 24 25 26
+43 44 45 46 47 48 49
+
+It is interesting to note that the odd squares lie along the bottom right diagonal, but what is more interesting is that 8 out of the 13 numbers lying along both diagonals are prime; that is, a ratio of 8/13 ≈ 62%.
+
+If one complete new layer is wrapped around the spiral above, a square spiral with side length 9 will be formed. If this process is continued, what is the side length of the square spiral for which the ratio of primes along both diagonals first falls below 10%?

--- a/058/spec/058_spec.rb
+++ b/058/spec/058_spec.rb
@@ -1,0 +1,9 @@
+require "./058"
+
+RSpec.describe Problem058 do
+  describe '#compute' do
+    it 'is solve Problem 058' do
+      expect(Problem058.new().compute()).to eq(26241)
+    end
+  end
+end

--- a/058/src/main.rs
+++ b/058/src/main.rs
@@ -1,0 +1,32 @@
+fn is_prime(n: u64) -> bool {
+    if n <= 1 {
+        return false;
+    }
+    let max = ((n as f64).sqrt() as u64) + 1;
+    for d in 2..max {
+        if n % d == 0 {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn main() {
+	let mut primes_on_diagonals = 0;
+
+	for len_spir in (3..).step_by(2) {
+		let last_diag = len_spir*len_spir;
+		let step_size = len_spir - 1;
+		let first_diag = last_diag - 3*step_size;
+
+		for num in (first_diag..last_diag).step_by(step_size) {
+			if is_prime(num as u64) { primes_on_diagonals += 1 }
+		}
+
+		let amount_diagonal_nums = 2*(len_spir - 1) + 1;
+		if 10*primes_on_diagonals < amount_diagonal_nums {
+			println!("{}", len_spir);
+			break;
+		}
+	}
+}


### PR DESCRIPTION
Solution strategy for problem 058:

* Start with side length = 3.
* Determine whether or not the numbers on the diagonal are prime numbers, and if so, add them to the array.
* Calculate (the length of the array of prime numbers) / (the length of the numbers on the spiral), and select the side length that is less than 0.1.